### PR TITLE
Pin black version to 21.7b0

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
        - uses: actions/checkout@v2
        - uses: actions/setup-python@v2
-       - uses: psf/black@master 
+       - uses: psf/black@21.7b0


### PR DESCRIPTION
Black has changed the default branch from `master` to `main`. Now, let's pin to a specific release so that the result stays consistent.